### PR TITLE
Handle Instagram 2FA via Telegram

### DIFF
--- a/post_to_instagram.py
+++ b/post_to_instagram.py
@@ -2,12 +2,34 @@ from instagrapi import Client
 import config
 import os
 import json
+from telegram_alert import send_telegram_alert, wait_for_telegram_code
+
+
+def login_instagram():
+    """Login to Instagram handling expired sessions and 2FA via Telegram."""
+    cl = Client()
+    if os.path.exists("session.json"):
+        try:
+            cl.load_settings("session.json")
+        except Exception as e:
+            print(f"⚠️ Failed to load session settings: {e}")
+
+    try:
+        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD)
+    except Exception as e:
+        print(f"🔑 Login requires verification: {e}")
+        send_telegram_alert("📲 Instagram verification needed. Please reply with the code.")
+        code = wait_for_telegram_code(timeout=600)
+        if not code:
+            raise Exception("No verification code received")
+        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD, verification_code=code)
+
+    cl.dump_settings("session.json")
+    return cl
 
 def post_to_instagram(image_path, caption):
     try:
-        cl = Client()
-        cl.load_settings("session.json")
-        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD)
+        cl = login_instagram()
 
         cl.photo_upload(
             path=image_path,


### PR DESCRIPTION
## Summary
- ask Telegram for a verification code when Instagram login fails
- add reusable helper to wait for any text message via Telegram
- login to Instagram using this helper and refresh the saved session

## Testing
- `python -m py_compile telegram_alert.py post_to_instagram.py`

------
https://chatgpt.com/codex/tasks/task_e_686ad1771fe883269a5c6d0c5a896d7f