### PR TITLE
Handle Instagram 2FA via Telegram

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,10 +3,20 @@ import time
 from create_post import create_instagram_post
 from post_to_instagram import post_to_instagram
 from quote_generator import generate_and_post_unique_quote
-from telegram_alert import send_telegram_photo, wait_for_telegram_reply, send_telegram_alert
+from telegram_alert import (
+    send_telegram_photo,
+    wait_for_telegram_reply,
+    send_telegram_alert,
+    check_for_command,
+    init_telegram_updates,
+)
 from dotenv import load_dotenv
 
 load_dotenv()
+init_telegram_updates()
+
+# Command message to trigger manual post generation
+RUN_COMMAND = "/run"
 
 # ✅ Optimized combined hashtag set (30 tags total)
 HASHTAGS = (
@@ -64,4 +74,7 @@ print("🔄 Bot is running. Waiting for scheduled posts...")
 
 while True:
     schedule.run_pending()
+    if check_for_command(RUN_COMMAND):
+        send_telegram_alert("🚀 Manual run triggered.")
+        run_bot()
     time.sleep(30)

--- a/post_to_instagram.py
+++ b/post_to_instagram.py
@@ -2,12 +2,34 @@ from instagrapi import Client
 import config
 import os
 import json
+from telegram_alert import send_telegram_alert, wait_for_telegram_code
+
+
+def login_instagram():
+    """Login to Instagram handling expired sessions and 2FA via Telegram."""
+    cl = Client()
+    if os.path.exists("session.json"):
+        try:
+            cl.load_settings("session.json")
+        except Exception as e:
+            print(f"⚠️ Failed to load session settings: {e}")
+
+    try:
+        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD)
+    except Exception as e:
+        print(f"🔑 Login requires verification: {e}")
+        send_telegram_alert("📲 Instagram verification needed. Please reply with the code.")
+        code = wait_for_telegram_code(timeout=600)
+        if not code:
+            raise Exception("No verification code received")
+        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD, verification_code=code)
+
+    cl.dump_settings("session.json")
+    return cl
 
 def post_to_instagram(image_path, caption):
     try:
-        cl = Client()
-        cl.load_settings("session.json")
-        cl.login(config.INSTAGRAM_USERNAME, config.INSTAGRAM_PASSWORD)
+        cl = login_instagram()
 
         cl.photo_upload(
             path=image_path,

--- a/telegram_alert.py
+++ b/telegram_alert.py
@@ -8,6 +8,9 @@ load_dotenv()
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
 
+# Track the last processed Telegram update so we don't reprocess old messages
+_LAST_UPDATE_ID = None
+
 def send_telegram_alert(message):
     url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
     payload = {
@@ -61,3 +64,78 @@ def wait_for_telegram_reply(timeout=10800):  # 3 hours
 
     print("⌛ Timeout waiting for Telegram reply.")
     return "timeout"
+
+
+def wait_for_telegram_code(timeout=300):
+    """Wait for any text reply on Telegram and return it.
+
+    Parameters
+    ----------
+    timeout : int
+        Seconds to wait before giving up.
+
+    Returns
+    -------
+    str or None
+        The message text or ``None`` if timed out.
+    """
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/getUpdates"
+    print("⏳ Waiting for your verification code...")
+    start_time = time.time()
+    last_update_id = None
+
+    # Skip old messages
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        updates = data.get("result", [])
+        if updates:
+            last_update_id = updates[-1]["update_id"]
+
+    while time.time() - start_time < timeout:
+        response = requests.get(url, params={"offset": (last_update_id + 1) if last_update_id else None})
+        if response.status_code == 200:
+            data = response.json()
+            updates = data.get("result", [])
+            for update in updates:
+                last_update_id = update["update_id"]
+                message = update.get("message", {}).get("text", "").strip()
+                chat_id = update.get("message", {}).get("chat", {}).get("id")
+                if str(chat_id) == TELEGRAM_CHAT_ID and message:
+                    print(f"✅ Got code: {message}")
+                    return message
+        time.sleep(5)
+
+    print("⌛ Timeout waiting for Telegram code.")
+    return None
+
+
+def init_telegram_updates():
+    """Initialize the last update ID to ignore old messages."""
+    global _LAST_UPDATE_ID
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/getUpdates"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        updates = data.get("result", [])
+        if updates:
+            _LAST_UPDATE_ID = updates[-1]["update_id"]
+
+
+def check_for_command(command="/run"):
+    """Return True if the specified command was sent via Telegram."""
+    global _LAST_UPDATE_ID
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/getUpdates"
+    params = {"offset": (_LAST_UPDATE_ID + 1) if _LAST_UPDATE_ID else None}
+    response = requests.get(url, params=params)
+    if response.status_code == 200:
+        data = response.json()
+        updates = data.get("result", [])
+        for update in updates:
+            _LAST_UPDATE_ID = update["update_id"]
+            message = update.get("message", {}).get("text", "").strip().lower()
+            chat_id = update.get("message", {}).get("chat", {}).get("id")
+            valid = [command.lower(), command.lstrip("/").lower()]
+            if str(chat_id) == TELEGRAM_CHAT_ID and message in valid:
+                return True
+    return False


### PR DESCRIPTION
## Summary
- ask Telegram for a verification code when Instagram login fails
- add reusable helper to wait for any text message via Telegram
- login to Instagram using this helper and refresh the saved session
- allow triggering a new post anytime via `/run` command

## Testing
- `python -m py_compile telegram_alert.py main.py post_to_instagram.py`


------
https://chatgpt.com/codex/tasks/task_e_686ad1771fe883269a5c6d0c5a896d7f