### PR TITLE
Improve error diagnostics via Telegram

### DIFF
--- a/create_post.py
+++ b/create_post.py
@@ -1,5 +1,6 @@
 from PIL import Image, ImageDraw, ImageFont
 import os
+from telegram_alert import send_error_report
 
 def create_instagram_post(quote, output_path="output/final_post.png"):
     try:
@@ -52,4 +53,5 @@ def create_instagram_post(quote, output_path="output/final_post.png"):
 
     except Exception as e:
         print("❌ Error creating image:", e)
+        send_error_report("Error creating image", e)
         return None

--- a/generate_ai_image.py
+++ b/generate_ai_image.py
@@ -2,6 +2,7 @@ import openai
 import config
 import requests
 import os
+from telegram_alert import send_error_report
 
 openai.api_key = config.OPENAI_API_KEY
 
@@ -38,4 +39,5 @@ def generate_ai_image(news_headline, output_path="output/ai_image.png"):
 
     except Exception as e:
         print("❌ Error generating image:", e)
+        send_error_report("Error generating image", e)
         return None

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from telegram_alert import (
     send_telegram_alert,
     check_for_command,
     init_telegram_updates,
+    send_error_report,
 )
 from dotenv import load_dotenv
 
@@ -63,7 +64,7 @@ def run_bot():
 
     except Exception as e:
         print("❌ Error during post:", e)
-        send_telegram_alert(f"❌ Bot crashed: {e}")
+        send_error_report("Bot crashed", e)
 
 # Schedule times (UTC)
 schedule.every().day.at("04:33").do(run_bot)

--- a/post_to_instagram.py
+++ b/post_to_instagram.py
@@ -2,7 +2,7 @@ from instagrapi import Client
 import config
 import os
 import json
-from telegram_alert import send_telegram_alert, wait_for_telegram_code
+from telegram_alert import send_telegram_alert, wait_for_telegram_code, send_error_report
 
 
 def login_instagram():
@@ -28,18 +28,26 @@ def login_instagram():
     return cl
 
 def post_to_instagram(image_path, caption):
-    try:
-        cl = login_instagram()
+    """Upload the image with the given caption, handling expired sessions."""
 
-        cl.photo_upload(
-            path=image_path,
-            caption=caption
-        )
-
-        print("✅ Post uploaded successfully!")
-
-    except Exception as e:
-        print("❌ Error uploading post:", e)
+    for attempt in range(2):
+        try:
+            cl = login_instagram()
+            cl.photo_upload(path=image_path, caption=caption)
+            print("✅ Post uploaded successfully!")
+            return
+        except Exception as e:
+            if (
+                ("login_required" in str(e).lower() or "403" in str(e))
+                and attempt == 0
+            ):
+                print("🔄 Session invalid, retrying login...")
+                if os.path.exists("session.json"):
+                    os.remove("session.json")
+                continue
+            print("❌ Error uploading post:", e)
+            send_error_report("Error uploading post", e)
+            break
 
 def save_posted_news(news_title):
     if not os.path.exists("posted_news.json"):

--- a/summarize_news.py
+++ b/summarize_news.py
@@ -1,5 +1,6 @@
 import openai
 import config
+from telegram_alert import send_error_report
 
 client = openai.OpenAI(api_key=config.OPENAI_API_KEY)
 
@@ -31,4 +32,5 @@ Format it exactly like:
 
     except Exception as e:
         print("❌ Error generating headline and caption:", e)
+        send_error_report("Error generating headline", e)
         return "Breaking News", "📰 Stay tuned for more updates."

--- a/telegram_alert.py
+++ b/telegram_alert.py
@@ -2,6 +2,7 @@ import os
 import requests
 import time
 from dotenv import load_dotenv
+import traceback
 
 load_dotenv()
 
@@ -33,6 +34,13 @@ def send_telegram_photo(image_path, caption=""):
             print(f"❌ Telegram Photo Error: {response.text}")
         else:
             print("🖼️ Telegram photo sent.")
+
+def send_error_report(context, exc):
+    """Send detailed error information via Telegram."""
+    tb = traceback.format_exc()
+    message = f"❌ {context}: {exc}\n\n{tb}"
+    # Telegram messages have a limit of 4096 characters
+    send_telegram_alert(message[-4096:])
 
 def wait_for_telegram_reply(timeout=10800):  # 3 hours
     url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/getUpdates"


### PR DESCRIPTION
## Summary
- notify Telegram when image creation, AI image generation, or summarization fails
- send detailed bot crash info to Telegram
- retry Instagram uploads when a 403 is encountered
- report full stack traces through new `send_error_report` utility

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686add255d4c83268b3bad0ce9211a9e