### PR TITLE
Use GPT image model for final birthday image

### DIFF
--- a/birthday_bot.py
+++ b/birthday_bot.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import schedule
 import time
-from PIL import Image, ImageDraw, ImageFont
 from telegram_alert import send_telegram_alert, send_telegram_photo
 from openai import OpenAI
 
@@ -82,30 +81,6 @@ def get_zodiac_symbol(month, day):
             return symbol
     return ""
 
-def compose_birthday_image(name, country, zodiac, base_image, output_path):
-    print(f"🖼️ Composing image for {name}")
-    image = Image.open(base_image).convert("RGBA")
-    draw = ImageDraw.Draw(image)
-
-    font_path = os.path.join(TEMPLATES_DIR, "OpenSans-Bold.ttf")
-    font = ImageFont.truetype(font_path, 80)
-
-    text = f"HAPPY BIRTHDAY {name.upper()}"
-    bbox = draw.textbbox((0, 0), text, font=font)
-    text_w = bbox[2] - bbox[0]
-    text_h = bbox[3] - bbox[1]
-    x = (image.width - text_w) // 2
-    y = image.height - text_h - 40
-    draw.text((x, y), text, font=font, fill="white")
-
-    draw.text((40, 40), zodiac, font=font, fill="white")
-    flag = FLAG_EMOJIS.get(country.upper(), country.upper())
-    draw.text((image.width - 200, 40), flag, font=font, fill="white")
-
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    image.convert("RGB").save(output_path)
-    send_telegram_alert(f"🖼️ Image composed for {name}")
-    return output_path
 
 def create_and_post(person):
     name = person["name"]
@@ -116,16 +91,11 @@ def create_and_post(person):
     msg = f"🎨 Generating AI image for {name}"
     print(msg)
     send_telegram_alert(msg)
-    ai_path = generate_ai_image(
-        name,
-        output_path=os.path.join(OUTPUT_DIR, f"{name}_ai.png"),
-    )
-    final_path = compose_birthday_image(
+    final_path = generate_ai_image(
         name,
         country,
         zodiac,
-        ai_path,
-        os.path.join(OUTPUT_DIR, f"{name}_birthday.png"),
+        output_path=os.path.join(OUTPUT_DIR, f"{name}_birthday.png"),
     )
     caption = f"Honoring {name}! Born on this day."
     msg = f"📤 Posting to Instagram: {caption}"

--- a/generate_ai_image.py
+++ b/generate_ai_image.py
@@ -1,30 +1,35 @@
 import os
-import requests
-import openai
+import base64
+from openai import OpenAI
 import config
 from telegram_alert import send_telegram_alert, send_telegram_photo
 
-openai.api_key = config.OPENAI_API_KEY
+client = OpenAI(api_key=config.OPENAI_API_KEY)
 
 
-def generate_ai_image(name: str, output_path: str = "output/ai_image.png") -> str:
-    """Generate a cinematic portrait of the given person using OpenAI's image API."""
+def generate_ai_image(name: str, country: str, zodiac: str, output_path: str = "output/ai_image.png") -> str:
+    """Generate a full birthday image using GPT Image."""
     prompt = (
-        f"ultra realistic cinematic portrait of {name}, confident expression, "
-        "warmly lit with a soft stage-like background"
+        f"Ultra-realistic high-resolution portrait of {name}, standing confidently on a softly lit stage with a dark gradient or black background. "
+        f"The person is smiling or appearing calm and composed, wearing formal attire, with a clean and cinematic aesthetic.\n"
+        f"Add bold centered text at the bottom that reads:\n'HAPPY BIRTHDAY\n{name}'\n"
+        f"Below that, include symmetrical zodiac symbols {zodiac} on the left and right and a stylish center icon representing {country}. "
+        "The image should look like a professional stage or award show photo, with soft shadows and magazine cover quality. "
+        "Maintain a warm, respectful, and celebratory vibe."
     )
+
     try:
-        response = openai.images.generate(
-            model="dall-e-3",
+        response = client.images.generate(
+            model="gpt-image-1",
             prompt=prompt,
             n=1,
             size="1024x1024",
+            quality="high",
         )
-        image_url = response.data[0].url
-        img_data = requests.get(image_url).content
+        image_base64 = response.data[0].b64_json
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "wb") as f:
-            f.write(img_data)
+            f.write(base64.b64decode(image_base64))
         msg = f"✅ AI Image saved to {output_path}"
         print(msg)
         send_telegram_alert(msg)


### PR DESCRIPTION
## Summary
- generate birthday images with the `gpt-image-1` model instead of DALL·E 3
- incorporate celebration text, zodiac and country directly in the generation prompt
- simplify bot workflow to skip manual image composition

## Testing
- `pytest -q`
- `python -m py_compile generate_ai_image.py birthday_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686b2bf0a05883268d1e1e667bc7959e